### PR TITLE
Let `requests` handle `kwargs`

### DIFF
--- a/src/ape_pie/client.py
+++ b/src/ape_pie/client.py
@@ -111,8 +111,6 @@ class APIClient(Session):
         See the upstream :meth:`requests.Session.request` documentation for the API
         reference.
         """
-        for attr, val in self._request_kwargs.items():
-            kwargs.setdefault(attr, val)
         url = self.to_absolute_url(url)
         with self._maybe_close_session():
             return super().request(method, url, *args, **kwargs)


### PR DESCRIPTION
I think `requests` will do what's necessary to merge `kwargs` from the session attributes