### PR TITLE
Py39 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,11 @@ dependencies = [
 
 [project.optional-dependencies]
 docs = ["sphinx", "sphinx-rtd-theme"]
-types = ["types-requests", "mypy"]
+types = [
+    "mypy",
+    "types-requests",
+    "typing_extensions",
+]
 dev = [
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 description = "A small API client abstraction layer on top of requests."
 readme = "README.rst"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 keywords = ["api client", "requests"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/ape_pie/client.py
+++ b/src/ape_pie/client.py
@@ -11,7 +11,7 @@ notably:
 from __future__ import annotations
 
 from contextlib import contextmanager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 # See https://github.com/gruns/furl/issues/148 for ongoing furl typing
 from furl import furl  # type: ignore
@@ -19,6 +19,11 @@ from requests import Response, Session
 
 from .exceptions import InvalidURLError
 from .typing import ConfigAdapter
+
+if TYPE_CHECKING:
+    # TODO Use typing.Self once we drop support for Py310
+    from typing_extensions import Self
+
 
 sentinel = object()
 
@@ -100,7 +105,7 @@ class APIClient(Session):
         return super().__exit__(*args)
 
     @classmethod
-    def configure_from(cls, adapter: ConfigAdapter, **kwargs):
+    def configure_from(cls: type[Self], adapter: ConfigAdapter, **kwargs) -> Self:
         base_url = adapter.get_client_base_url()
         session_kwargs = adapter.get_client_session_kwargs()
         return cls(base_url, session_kwargs, **kwargs)

--- a/src/ape_pie/client.py
+++ b/src/ape_pie/client.py
@@ -7,6 +7,9 @@ notably:
 * Implementing the client as a ``Session`` subclass
 * Providing a base_url and making this absolute
 """
+
+from __future__ import annotations
+
 from contextlib import contextmanager
 from typing import Any
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311}
+    py{39,310,311}
     mypy
     isort
     black


### PR DESCRIPTION
The first commit is for the unlucky souls that still have a CI on py3.9

The latter 2 do the same as #2, but using the implementation that became the std lib one in 3.11

Closes #2 