### PR TITLE
Avoid surprising mutation and remove Any from the kwargs type.

### DIFF
--- a/src/ape_pie/typing.py
+++ b/src/ape_pie/typing.py
@@ -1,4 +1,41 @@
-from typing import Any, Protocol
+from __future__ import annotations
+
+from http.cookiejar import CookieJar
+from typing import TYPE_CHECKING, Protocol, TypedDict
+
+if TYPE_CHECKING:
+    # imports from stubs
+    from _typeshed import Incomplete
+    from requests.api import _HeadersMapping
+    from requests.sessions import (
+        _Auth,
+        _Cert,
+        _Data,
+        _Files,
+        _HooksInput,
+        _Params,
+        _TextMapping,
+        _Timeout,
+        _Verify,
+    )
+
+
+class RequestKwargs(TypedDict, total=False):
+    # Supposed to be ParamSpec.kwargs of `requests.request`
+    params: _Params
+    data: _Data
+    headers: _HeadersMapping
+    cookies: CookieJar | _TextMapping | None
+    files: _Files | None
+    auth: _Auth | None
+    timeout: _Timeout | None
+    allow_redirects: bool
+    proxies: _TextMapping | None
+    hooks: _HooksInput | None
+    stream: bool | None
+    verify: _Verify | None
+    cert: _Cert | None
+    json: Incomplete
 
 
 class ConfigAdapter(Protocol):
@@ -8,7 +45,7 @@ class ConfigAdapter(Protocol):
         """
         ...
 
-    def get_client_session_kwargs(self) -> dict[str, Any]:  # pragma: no cover
+    def get_client_session_kwargs(self) -> RequestKwargs:  # pragma: no cover
         """
         Return kwargs to feed to :class:`requests.Session` when using the client.
 

--- a/tests/test_client_api.py
+++ b/tests/test_client_api.py
@@ -3,6 +3,7 @@ from requests import Session
 from requests.auth import HTTPBasicAuth
 
 from ape_pie import APIClient
+from ape_pie.typing import RequestKwargs
 
 
 @pytest.mark.parametrize("attr", Session.__attrs__)
@@ -32,9 +33,30 @@ def test_can_override_defaults(attr, value):
     assert attr in Session.__attrs__
     vanilla_session = Session()
 
-    client = APIClient("https://example.com", {attr: value})
+    client = APIClient("https://example.com", {attr: value})  # type: ignore[assignment]
 
     vanilla_value = getattr(vanilla_session, attr)
     client_value = getattr(client, attr)
     assert client_value != vanilla_value
     assert client_value == value
+
+
+def test_config_does_not_mutate():
+    imported_settings: RequestKwargs = {
+        "auth": ("djkhaled", "youplayedyourself"),
+    }
+
+    class MyConfig:
+        @staticmethod
+        def get_client_base_url():
+            return "https://example.com"
+
+        @staticmethod
+        def get_client_session_kwargs():
+            return imported_settings
+
+    one = APIClient.configure_from(MyConfig)
+    another_one = APIClient.configure_from(MyConfig)
+
+    assert one.auth == ("djkhaled", "youplayedyourself")
+    assert another_one.auth == ("djkhaled", "youplayedyourself")

--- a/tests/test_config_adapter.py
+++ b/tests/test_config_adapter.py
@@ -9,6 +9,7 @@ from requests_mock import ANY
 
 from ape_pie import APIClient
 from ape_pie.exceptions import InvalidURLError
+from ape_pie.typing import RequestKwargs
 
 
 class TestConfigAdapter:
@@ -17,7 +18,7 @@ class TestConfigAdapter:
         return "https://from-factory.example.com"
 
     @staticmethod
-    def get_client_session_kwargs():
+    def get_client_session_kwargs() -> RequestKwargs:
         return {
             "verify": False,
             "timeout": 20,

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ commands = mypy src
 [testenv:isort]
 extras = dev
 skipsdist = True
-commands = isort --check-only --diff .
+commands = isort --check-only --diff src tests
 
 [testenv:black]
 extras = dev
@@ -39,7 +39,7 @@ commands = black --check src tests docs
 [testenv:flake8]
 extras = dev
 skipsdist = True
-commands = flake8 .
+commands = flake8 src tests
 
 [testenv:docs]
 basepython=python


### PR DESCRIPTION
There is no gitmoji for happy little accident. But this
```python
def test_config_does_not_mutate():
    imported_settings: RequestKwargs = {
        "auth": ("djkhaled", "youplayedyourself"),
    }

    class MyConfig:
        @staticmethod
        def get_client_base_url():
            return "https://example.com"

        @staticmethod
        def get_client_session_kwargs():
            return imported_settings

    one = APIClient.configure_from(MyConfig)
    another_one = APIClient.configure_from(MyConfig)

    assert one.auth == ("djkhaled", "youplayedyourself")
    assert another_one.auth == ("djkhaled", "youplayedyourself")
```